### PR TITLE
Fix preg_match #2 argument

### DIFF
--- a/src/Authentication/Method/HttpAuthorizationMethod.php
+++ b/src/Authentication/Method/HttpAuthorizationMethod.php
@@ -14,7 +14,7 @@ class HttpAuthorizationMethod extends BaseMethod
      */
     protected function getCredentials(Request $request): ?string
     {
-        $authorization = $request->header($this->name);
+        $authorization = $request->header($this->name, '');
         if (preg_match($this->pattern, $authorization, $matches)) {
             return $matches[1];
         }


### PR DESCRIPTION
preg_match requires #2 argument is not null