### PR TITLE
Update HttpAuthorizationMethod.php, prevent null value pass to preg_match

### DIFF
--- a/src/Authentication/Method/HttpAuthorizationMethod.php
+++ b/src/Authentication/Method/HttpAuthorizationMethod.php
@@ -15,7 +15,7 @@ class HttpAuthorizationMethod extends BaseMethod
     protected function getCredentials(Request $request): ?string
     {
         $authorization = $request->header($this->name, '');
-        if (preg_match($this->pattern, $authorization, $matches)) {
+        if ($authorization && preg_match($this->pattern, $authorization, $matches)) {
             return $matches[1];
         }
 


### PR DESCRIPTION
for some reason the header is null cause error to this function (PHP 8.2)
```
Passing null to parameter #2 ($subject) of type string is deprecated in ../vendor/webman-tech/auth/src/Authentication/Method/HttpAuthorizationMethod.php:18
```